### PR TITLE
Enable directory processing for MetadataExtractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ The example archive `document/Veg kartering - habitatkaart 2021-2023.zip`
 is included in the repository. After building, execute the extractor:
 
 ```bash
-java -cp target/classes:<dependencies> MetadataExtractor
+java -cp target/classes:<dependencies> MetadataExtractor [path]
 ```
 
-A `report.json` file will appear with metadata for every file found inside the
-archive.
+The optional `path` argument can point to a file or directory. If it is a file
+(for example the included ZIP archive) the
+results are written to `report.json`. When `path` is a directory every regular
+file inside that directory is processed individually and a file named
+`report-<filename>.json` will be created for each one.
 
 ### Running from IntelliJ
 


### PR DESCRIPTION
## Summary
- allow `MetadataExtractor` to accept an optional path argument
- if a directory is supplied, process each file and write `report-<filename>.json`
- document new behaviour in README

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685d6ea8ee888332bcf17dd1d73f6c56