### PR TITLE
Refactor for readability

### DIFF
--- a/src/CkanResource.java
+++ b/src/CkanResource.java
@@ -23,22 +23,25 @@ public final class CkanResource {
         return this.data;
     }
 
+    @Override
     public String toString() {
-        return "CkanResource{data=" + String.valueOf(this.data) + "}";
+        return "CkanResource{data=" + data + '}';
     }
 
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
-        } else if (o != null && this.getClass() == o.getClass()) {
-            CkanResource that = (CkanResource)o;
-            return Objects.equals(this.data, that.data);
-        } else {
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        CkanResource that = (CkanResource) o;
+        return Objects.equals(data, that.data);
     }
 
+    @Override
     public int hashCode() {
-        return Objects.hash(new Object[]{this.data});
+        return Objects.hash(data);
     }
 }

--- a/src/DefaultCkanResourceFormat.java
+++ b/src/DefaultCkanResourceFormat.java
@@ -99,10 +99,33 @@ public class DefaultCkanResourceFormat implements ICkanResourceFormatter {
     }
 
     private static Optional<Instant> parse(String dt) {
-        if (dt != null && !dt.isBlank()) {
-            List<Supplier<Optional<Instant>>> ps = List.of((Supplier)() -> Optional.of(OffsetDateTime.parse(dt).toInstant()), (Supplier)() -> Optional.of(ZonedDateTime.parse(dt).toInstant()), (Supplier)() -> Optional.of(Instant.parse(dt)), (Supplier)() -> Optional.of(LocalDateTime.parse(dt).atZone(ZoneId.systemDefault()).toInstant()), (Supplier)() -> Optional.of(LocalDate.parse(dt).atStartOfDay(ZoneId.systemDefault()).toInstant()));
-            return ps.stream().map(Supplier::get).filter(Optional::isPresent).map(Optional::get).findFirst();
-        } else {
+        if (dt == null || dt.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(OffsetDateTime.parse(dt).toInstant());
+        } catch (Exception ignored) { }
+
+        try {
+            return Optional.of(ZonedDateTime.parse(dt).toInstant());
+        } catch (Exception ignored) { }
+
+        try {
+            return Optional.of(Instant.parse(dt));
+        } catch (Exception ignored) { }
+
+        try {
+            return Optional.of(LocalDateTime.parse(dt)
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant());
+        } catch (Exception ignored) { }
+
+        try {
+            return Optional.of(LocalDate.parse(dt)
+                    .atStartOfDay(ZoneId.systemDefault())
+                    .toInstant());
+        } catch (Exception ignored) {
             return Optional.empty();
         }
     }

--- a/src/DefaultFileTypeFilter.java
+++ b/src/DefaultFileTypeFilter.java
@@ -1,5 +1,4 @@
 import java.util.Objects;
-import java.util.stream.Stream;
 
 public class DefaultFileTypeFilter implements IFileTypeFilter {
     private final ExtractorConfiguration config;
@@ -8,6 +7,11 @@ public class DefaultFileTypeFilter implements IFileTypeFilter {
         this.config = (ExtractorConfiguration)Objects.requireNonNull(config, "Configuratie mag niet null zijn");
     }
 
+    /**
+     * Determine whether the given file should be processed based on its name
+     * and configured ignore rules.
+     */
+    @Override
     public boolean isFileTypeRelevant(String entryName) {
         if (entryName == null || entryName.isBlank()) {
             return false;

--- a/src/ICkanResourceFormatter.java
+++ b/src/ICkanResourceFormatter.java
@@ -1,5 +1,16 @@
 import org.apache.tika.metadata.Metadata;
 
+/** Formats extracted metadata into a CKAN resource representation. */
 interface ICkanResourceFormatter {
-    CkanResource format(String var1, Metadata var2, String var3, String var4);
+    /**
+     * @param entryName       the original entry name or filename
+     * @param metadata        metadata as produced by the extractor
+     * @param text            extracted textual content
+     * @param sourceIdentifier identifier used for error reporting
+     * @return a CKAN resource ready for serialization
+     */
+    CkanResource format(String entryName,
+                        Metadata metadata,
+                        String text,
+                        String sourceIdentifier);
 }

--- a/src/IFileTypeFilter.java
+++ b/src/IFileTypeFilter.java
@@ -1,4 +1,11 @@
 @FunctionalInterface
 interface IFileTypeFilter {
-    boolean isFileTypeRelevant(String var1);
+    /**
+     * Determines whether the given entry should be processed based on its
+     * filename or extension.
+     *
+     * @param entryName name of the entry (may include path information)
+     * @return {@code true} if the entry is relevant for extraction
+     */
+    boolean isFileTypeRelevant(String entryName);
 }

--- a/src/IMetadataProvider.java
+++ b/src/IMetadataProvider.java
@@ -5,8 +5,16 @@ import org.apache.tika.metadata.Metadata;
 import org.xml.sax.SAXException;
 
 interface IMetadataProvider {
-    ExtractionOutput extract(InputStream var1, int var2) throws IOException, TikaException, SAXException, Exception;
+    /**
+     * Extract metadata and text from the provided stream.
+     *
+     * @param inputStream   the content to parse
+     * @param maxTextLength maximum length of text to extract
+     * @return extracted metadata and text
+     */
+    ExtractionOutput extract(InputStream inputStream, int maxTextLength)
+            throws IOException, TikaException, SAXException, Exception;
 
-    public static record ExtractionOutput(Metadata metadata, String text) {
-    }
+    /** Simple holder for the parser output. */
+    public static record ExtractionOutput(Metadata metadata, String text) { }
 }

--- a/src/ISourceProcessor.java
+++ b/src/ISourceProcessor.java
@@ -1,6 +1,21 @@
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Processes a single source path. Implementations may handle regular files or
+ * container formats (for example ZIP archives).
+ */
 interface ISourceProcessor {
-    void processSource(Path var1, String var2, List<CkanResource> var3, List<ProcessingError> var4, List<IgnoredEntry> var5);
+    /**
+     * @param sourcePath    the actual file on disk that is being processed
+     * @param containerPath a human readable identifier for the current entry
+     * @param results       list to add successfully extracted resources to
+     * @param errors        list to add encountered processing errors to
+     * @param ignored       list to add skipped entries to
+     */
+    void processSource(Path sourcePath,
+                       String containerPath,
+                       List<CkanResource> results,
+                       List<ProcessingError> errors,
+                       List<IgnoredEntry> ignored);
 }

--- a/src/MetadataExtractor.java
+++ b/src/MetadataExtractor.java
@@ -74,12 +74,12 @@ public class MetadataExtractor {
     }
 
     private boolean isZipFile(Path path) {
-        if (path != null && Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
-            String name = path.getFileName().toString().toLowerCase();
-            return config.getSupportedZipExtensions().stream()
-                    .anyMatch(ext -> name.endsWith(ext.toLowerCase()));
+        if (path == null || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            return false;
         }
-        return false;
+        String name = path.getFileName().toString().toLowerCase();
+        return config.getSupportedZipExtensions().stream()
+                .anyMatch(ext -> name.endsWith(ext.toLowerCase()));
     }
 
     private static LanguageDetector loadTikaLanguageDetector() {

--- a/src/NonClosingInputStream.java
+++ b/src/NonClosingInputStream.java
@@ -2,23 +2,32 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Wrapper stream that ignores {@link #close()} calls. Useful when a consumer
+ * should not close the underlying stream.
+ */
 class NonClosingInputStream extends FilterInputStream {
     protected NonClosingInputStream(InputStream in) {
         super(in);
     }
 
-    public void close() throws IOException {
+    @Override
+    public void close() {
+        // intentionally empty
     }
 
+    @Override
     public synchronized void mark(int readlimit) {
-        this.in.mark(readlimit);
+        in.mark(readlimit);
     }
 
+    @Override
     public synchronized void reset() throws IOException {
-        this.in.reset();
+        in.reset();
     }
 
+    @Override
     public boolean markSupported() {
-        return this.in.markSupported();
+        return in.markSupported();
     }
 }

--- a/src/ProcessingReport.java
+++ b/src/ProcessingReport.java
@@ -29,8 +29,12 @@ public final class ProcessingReport {
         return this.ignored;
     }
 
+    @Override
     public String toString() {
-        int var10000 = this.results.size();
-        return "ProcessingReport{resultaten=" + var10000 + ", fouten=" + this.errors.size() + ", genegeerd=" + this.ignored.size() + "}";
+        return "ProcessingReport{" +
+                "resultaten=" + results.size() +
+                ", fouten=" + errors.size() +
+                ", genegeerd=" + ignored.size() +
+                '}';
     }
 }

--- a/src/SingleFileProcessor.java
+++ b/src/SingleFileProcessor.java
@@ -6,29 +6,45 @@ import java.nio.file.Path;
 import java.util.List;
 
 public class SingleFileProcessor extends AbstractSourceProcessor {
-    public SingleFileProcessor(IFileTypeFilter ff, IMetadataProvider mp, ICkanResourceFormatter rf, ExtractorConfiguration cfg) {
+    public SingleFileProcessor(IFileTypeFilter ff,
+                               IMetadataProvider mp,
+                               ICkanResourceFormatter rf,
+                               ExtractorConfiguration cfg) {
         super(ff, mp, rf, cfg);
     }
 
-    public void processSource(Path sourcePath, String containerPath, List<CkanResource> results, List<ProcessingError> errors, List<IgnoredEntry> ignored) {
+    @Override
+    public void processSource(Path sourcePath,
+                              String containerPath,
+                              List<CkanResource> results,
+                              List<ProcessingError> errors,
+                              List<IgnoredEntry> ignored) {
         String sourceIdentifier = sourcePath.toString();
         String filename = sourcePath.getFileName().toString();
-        if (!this.fileFilter.isFileTypeRelevant(filename)) {
-            ignored.add(new IgnoredEntry(sourceIdentifier, "Irrelevant bestandstype of naam."));
-        } else {
-            try (InputStream stream = new BufferedInputStream(Files.newInputStream(sourcePath))) {
-                IMetadataProvider.ExtractionOutput output = this.metadataProvider.extract(stream, this.config.getMaxExtractedTextLength());
-                CkanResource resource = this.resourceFormatter.format(filename, output.metadata(), output.text(), sourceIdentifier);
-                results.add(resource);
-            } catch (IOException e) {
-                errors.add(new ProcessingError(sourceIdentifier, "I/O Fout bij lezen bestand: " + e.getMessage()));
-                System.err.println("FOUT: I/O Probleem bestand '" + sourceIdentifier + "': " + e.getMessage());
-            } catch (Exception e) {
-                String var10004 = e.getClass().getSimpleName();
-                errors.add(new ProcessingError(sourceIdentifier, "Fout bij verwerken bestand: " + var10004 + " - " + e.getMessage()));
-                System.err.println("FOUT: Probleem verwerken bestand '" + sourceIdentifier + "': " + e.getMessage());
-            }
 
+        if (!fileFilter.isFileTypeRelevant(filename)) {
+            ignored.add(new IgnoredEntry(sourceIdentifier, "Irrelevant bestandstype of naam."));
+            return;
+        }
+
+        try (InputStream stream = new BufferedInputStream(Files.newInputStream(sourcePath))) {
+            IMetadataProvider.ExtractionOutput output =
+                    metadataProvider.extract(stream, config.getMaxExtractedTextLength());
+            CkanResource resource = resourceFormatter.format(
+                    filename,
+                    output.metadata(),
+                    output.text(),
+                    sourceIdentifier);
+            results.add(resource);
+        } catch (IOException e) {
+            errors.add(new ProcessingError(sourceIdentifier,
+                    "I/O Fout bij lezen bestand: " + e.getMessage()));
+            System.err.println("FOUT: I/O Probleem bestand '" + sourceIdentifier + "': " + e.getMessage());
+        } catch (Exception e) {
+            errors.add(new ProcessingError(sourceIdentifier,
+                    "Fout bij verwerken bestand: "
+                            + e.getClass().getSimpleName() + " - " + e.getMessage()));
+            System.err.println("FOUT: Probleem verwerken bestand '" + sourceIdentifier + "': " + e.getMessage());
         }
     }
 }

--- a/src/TikaMetadataProvider.java
+++ b/src/TikaMetadataProvider.java
@@ -20,7 +20,10 @@ public class TikaMetadataProvider implements IMetadataProvider {
         this.tikaParser = (Parser)Objects.requireNonNull(parser, "Tika Parser mag niet null zijn");
     }
 
-    public IMetadataProvider.ExtractionOutput extract(InputStream inputStream, int maxTextLength) throws IOException, TikaException, SAXException, Exception {
+    @Override
+    public IMetadataProvider.ExtractionOutput extract(InputStream inputStream,
+                                                      int maxTextLength)
+            throws IOException, TikaException, SAXException, Exception {
         BodyContentHandler contentHandler = new BodyContentHandler(maxTextLength);
         Metadata metadata = new Metadata();
         ParseContext parseContext = new ParseContext();

--- a/src/ZipSourceProcessor.java
+++ b/src/ZipSourceProcessor.java
@@ -21,12 +21,12 @@ public class ZipSourceProcessor extends AbstractSourceProcessor {
     }
 
     @Override
-    public void processSource(Path zipPath,
+    public void processSource(Path sourcePath,
                               String containerPath,
                               List<CkanResource> results,
                               List<ProcessingError> errors,
                               List<IgnoredEntry> ignored) {
-        try (InputStream fis = Files.newInputStream(zipPath);
+        try (InputStream fis = Files.newInputStream(sourcePath);
              BufferedInputStream bis = new BufferedInputStream(fis);
              ZipInputStream zis = new ZipInputStream(bis)) {
 


### PR DESCRIPTION
## Summary
- refine interfaces and processors
- clean up file type filtering logic
- improve CKAN resource representation
- streamline date parsing and helper utilities

## Testing
- `javac -d /tmp/out $(find src -name '*.java')` *(fails: package org.apache.tika.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_686565688df88332b77f9fa5e45df48c